### PR TITLE
utils/code.go 增加Marshal方法; json请求体改用自定义Marshal方法

### DIFF
--- a/models/PrepareRequest.go
+++ b/models/PrepareRequest.go
@@ -3,7 +3,6 @@ package models
 import (
 	"bytes"
 	"encoding/base64"
-	jsonp "encoding/json"
 	"errors"
 	"fmt"
 	"github.com/wangluozhe/fhttp"
@@ -139,7 +138,7 @@ func (pr *PrepareRequest) Prepare_body(data *url.Values, files *url.Files, json 
 	}
 	if data == nil && json != nil {
 		content_type = "application/json"
-		json_byte, err := jsonp.Marshal(json)
+		json_byte, err := utils.Marshal(json)
 		if err != nil {
 			return err
 		}

--- a/utils/code.go
+++ b/utils/code.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"net/url"
 	"regexp"
@@ -178,4 +179,18 @@ func UnEscape(s interface{}) string {
 	})
 	str = DecodeURIComponent(str)
 	return str
+}
+
+// Marshal 避免json.Marshal对 "<", ">", "&" 等字符进行HTML编码
+func Marshal(data interface{}) ([]byte, error) {
+	var buffer bytes.Buffer
+
+	encoder := json.NewEncoder(&buffer)
+
+	// 禁用HTML转义
+	encoder.SetEscapeHTML(false)
+
+	err := encoder.Encode(data)
+
+	return buffer.Bytes(), err
 }


### PR DESCRIPTION
Akamai发送sensor_data时，使用json.Marshal会对<、>、&等字符进行HTML编码，将PrepareRequest.go中对json请求体的解析替换为自定义方法，可避免编码，使请求体保持原状